### PR TITLE
Add proper TestResultsTracker unit tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     implementation(kotlin("stdlib"))
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.2")
+    testImplementation("org.mockito:mockito-core:5.5.0")
 }
 
 tasks.test {

--- a/src/test/kotlin/com/danmarshall/tddhelper/services/TestResultsTrackerTest.kt
+++ b/src/test/kotlin/com/danmarshall/tddhelper/services/TestResultsTrackerTest.kt
@@ -1,38 +1,38 @@
 package com.danmarshall.tddhelper.services
 
 import com.intellij.execution.testframework.AbstractTestProxy
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.Assertions.*
+import com.intellij.execution.testframework.TestStatusListener
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import org.mockito.Mockito.*
 
-class TestResultsTrackerTest {
+class TestResultsTrackerTest : BasePlatformTestCase() {
 
-    // This is a placeholder test class that would be expanded with actual tests
-    // In a real implementation, we would use proper mocking of IntelliJ components
-    
-    @Test
-    fun `test initial state has no failures`() {
-        // In a real test, we would properly mock the ApplicationManager and other components
-        // For now, this is just a placeholder to demonstrate the test structure
-        
-        // val tracker = TestResultsTracker()
-        // assertFalse(tracker.hasFailures())
-        // assertTrue(tracker.getFailedTests().isEmpty())
-        
-        // Placeholder assertion to make the test pass
-        assertTrue(true)
+    private lateinit var tracker: TestResultsTracker
+
+    override fun setUp() {
+        super.setUp()
+        tracker = ApplicationManager.getApplication().getService(TestResultsTracker::class.java)
     }
-    
-    @Test
-    fun `test updateTestResults with failed tests`() {
-        // In a real test, we would:
-        // 1. Create mock AbstractTestProxy objects
-        // 2. Configure them to return appropriate values for isDefect, etc.
-        // 3. Call updateTestResults with the mock
-        // 4. Verify that hasFailures is true and failedTests contains the expected tests
-        
-        // Placeholder assertion to make the test pass
-        assertTrue(true)
+
+    fun testInitialStateHasNoFailures() {
+        assertFalse(tracker.hasFailures())
+        assertTrue(tracker.getFailedTests().isEmpty())
+    }
+
+    fun testUpdateTestResultsWithFailedTests() {
+        val failingTest = mock(AbstractTestProxy::class.java)
+        `when`(failingTest.isDefect).thenReturn(true)
+        `when`(failingTest.isInProgress).thenReturn(false)
+        `when`(failingTest.getAllTests()).thenReturn(listOf(failingTest))
+
+        val root = mock(AbstractTestProxy::class.java)
+        `when`(root.isDefect).thenReturn(true)
+        `when`(root.getAllTests()).thenReturn(listOf(failingTest))
+
+        myFixture.project.messageBus.syncPublisher(TestStatusListener.TEST_STATUS).testSuiteFinished(root)
+
+        assertTrue(tracker.hasFailures())
+        assertEquals(listOf(failingTest), tracker.getFailedTests())
     }
 }


### PR DESCRIPTION
## Summary
- add Mockito test dependency
- implement TestResultsTrackerTest using `BasePlatformTestCase`

## Testing
- `gradle test` *(fails: Cannot find builtin plugin 'com.intellij.java')*

------
https://chatgpt.com/codex/tasks/task_e_684a589ccb9c83218142cb3886629833