### PR TITLE
Add GitHub Actions for CI and releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Set up Gradle
+        uses: gradle/gradle-build-action@v2
+      - name: Run Tests
+        run: ./gradlew test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Set up Gradle
+        uses: gradle/gradle-build-action@v2
+      - name: Publish Plugin
+        run: ./gradlew publishPlugin
+        env:
+          PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+          PRIVATE_KEY_PASSWORD: ${{ secrets.PRIVATE_KEY_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ To contribute to the TddHelper plugin:
 
 For more detailed instructions, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
+## CI/CD
+
+This repository uses GitHub Actions to run tests on pull requests and to publish new plugin versions on release creation.
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.


### PR DESCRIPTION
## Summary
- run tests on pushes and pull requests
- publish plugin on GitHub release events
- document the new CI/CD automation in README

## Testing
- `./gradlew test` *(fails: Could not finish due to Gradle download and JDK setup)*

------
https://chatgpt.com/codex/tasks/task_e_684a7ec079c48321b3d9eeff1b08dde2